### PR TITLE
Use fixed matrix in 関節操作

### DIFF
--- a/HiroNXInterface/HiroNXGUI/HiroNXGUI.xrc
+++ b/HiroNXInterface/HiroNXGUI/HiroNXGUI.xrc
@@ -19,7 +19,7 @@
 							<flag>wxALIGN_CENTER_VERTICAL|wxALL</flag>
 							<border>5</border>
 							<object class="wxStaticText" name="m_staticText5">
-								<label>RTC Staus</label>
+								<label>RTC Status</label>
 							</object>
 						</object>
 						<object class="sizeritem">

--- a/HiroNXInterface/HiroNXGUI/HiroNXGUI.xrc
+++ b/HiroNXInterface/HiroNXGUI/HiroNXGUI.xrc
@@ -368,7 +368,7 @@
 										<object class="wxScrolledWindow" name="m_body_joints_panel">
 											<style>wxHSCROLL|wxSIMPLE_BORDER|wxVSCROLL</style>
 											<object class="wxFlexGridSizer">
-												<rows>2</rows>
+												<rows>3</rows>
 												<cols>4</cols>
 												<vgap>0</vgap>
 												<hgap>0</hgap>
@@ -387,7 +387,7 @@
 													<object class="wxScrolledWindow" name="m_left_joints_panel">
 														<style>wxHSCROLL|wxSIMPLE_BORDER|wxVSCROLL</style>
 														<object class="wxFlexGridSizer">
-															<rows>2</rows>
+															<rows>11</rows>
 															<cols>4</cols>
 															<vgap>0</vgap>
 															<hgap>0</hgap>
@@ -403,7 +403,7 @@
 													<object class="wxScrolledWindow" name="m_right_joints_panel">
 														<style>wxHSCROLL|wxSIMPLE_BORDER|wxVSCROLL</style>
 														<object class="wxFlexGridSizer">
-															<rows>2</rows>
+															<rows>11</rows>
 															<cols>4</cols>
 															<vgap>0</vgap>
 															<hgap>0</hgap>

--- a/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py
+++ b/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py
@@ -194,7 +194,7 @@ class MyApp(wx.App):
         for code in joints:
             if code.find('---') == 0 and last_panel:
                 sizer = last_panel.Sizer
-                sizer.Rows = sizer.Rows + 1
+                #sizer.Rows = sizer.Rows + 1
                 for i in range(4):
                     line = wx.StaticText(last_panel, -1)
                     line.Label = ' '


### PR DESCRIPTION
Wx3.0以降では
```
./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py
./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI
<wx._controls.Button; proxy of <Swig Object of type 'wxButton *' at 0x55b2767ade00> > <wx._controls.Button; proxy of <Swig Object of type 'wxButton *' at 0x55b2767b80d0> >
Traceback (most recent call last):
  File "./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py", line 368, in <module>
    app = MyApp(False)
  File "/usr/lib/python2.7/dist-packages/wx-3.0-gtk3/wx/_core.py", line 8628, in __init__
    self._BootstrapApp()
  File "/usr/lib/python2.7/dist-packages/wx-3.0-gtk3/wx/_core.py", line 8196, in _BootstrapApp
    return _core_.PyApp__BootstrapApp(*args, **kwargs)
  File "./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py", line 95, in OnInit
    self.init_frame()
  File "./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py", line 146, in init_frame
    self.InitJointsPanel(joints, panels)
  File "./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py", line 204, in InitJointsPanel
    self.addJoint(last_panel, code)
  File "./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py", line 247, in addJoint
    sizer.Add(label,    1, wx.ALIGN_CENTER_VERTICAL|wx.ALIGN_RIGHT)
  File "/usr/lib/python2.7/dist-packages/wx-3.0-gtk3/wx/_core.py", line 14453, in Add
    return _core_.Sizer_Add(*args, **kwargs)
wx._core.PyAssertionError: C++ assertion "Assert failure" failed at ../src/common/sizer.cpp(1401) in DoInsert(): too many items (9 > 4*2) in grid sizer (maybe you should omit the number of either rows or columns?)
```

同様の議論がhttps://discuss.wxpython.org/t/error-in-v-3-0/29537 でもされています。
より新しいOSではWx3.0以降が内蔵されていて、この変更を施さないと最近の環境では上記のエラーを発生します。

## 修正
XRCのグリッドサイズを定める部分に行の個数をハードコードし、

https://github.com/kensuke-harada/hironx-interface/blob/cda591280d2581b85a0c565db252be2071cdbcfd/HiroNXInterface/HiroNXGUI/WxHiroNXGUI.py#L194-L201
にある、様々な個数の関節に対応できる設計(197行目)を一旦無効化

## 再現方法
1. ```xhost +local:user```
2. ```docker run --rm -it -e DISPLAY=unix$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/kazuki0824/hlab-nxo-setup:melodic```
3. コンテナ内で以下を実行する
```bash
cd ./hlab-nxo-setup/externals/hironx-interface/HiroNXInterface/HiroNXGUI/
bash ./idlcompile.sh
./WxHiroNXGUI.py
```
4. ```xhost -local:user```